### PR TITLE
Prevent mouseup from triggering the event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,17 @@ export function clickOutside(
   node: HTMLElement,
   handler: () => void
 ): { destroy: () => void } {
-  const onClick = (event: MouseEvent) =>
+  const onMouseDown = (event: MouseEvent) =>
     node &&
     !node.contains(event.target as HTMLElement) &&
     !event.defaultPrevented &&
     handler();
 
-  document.addEventListener('click', onClick, true);
+  document.addEventListener('mousedown', onMouseDown, true);
 
   return {
     destroy() {
-      document.removeEventListener('click', onClick, true);
+      document.removeEventListener('mousedown', onMouseDown, true);
     },
   };
 }


### PR DESCRIPTION
Prevent this function from being triggered if you mouse-down within the element, and then mouse-up outside of it. Imo, this should not count as a "click".