### PR TITLE
Fix false positives when the user clicks up outside the element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,33 @@
-export function clickOutside(
-  node: HTMLElement,
-  handler: () => void
-): { destroy: () => void } {
-  const onClick = (event: MouseEvent) =>
-    node &&
-    !node.contains(event.target as HTMLElement) &&
-    !event.defaultPrevented &&
-    handler();
+export function clickOutside(node: HTMLElement, handler: () => void): { destroy: () => void } {
+	let pointerDownStartedInside = false;
 
-  document.addEventListener('click', onClick, true);
+	const onPointerDown = (event: PointerEvent) => {
+		if (node && node.contains(event.target as HTMLElement) && !event.defaultPrevented) {
+			// Set our flag to True if the pointer started from within the node.
+			// This is needed to prevent regular `pointerup` event from triggering the handler
+			pointerDownStartedInside = true;
+		}
+	};
 
-  return {
-    destroy() {
-      document.removeEventListener('click', onClick, true);
-    },
-  };
+	const onPointerUp = (event: PointerEvent) => {
+		if (node && !node.contains(event.target as HTMLElement) && !event.defaultPrevented) {
+			if (pointerDownStartedInside) {
+			} else {
+				handler();
+			}
+		}
+
+		// Reset the flag
+		pointerDownStartedInside = false;
+	};
+
+	document.addEventListener('pointerup', onPointerUp, true);
+	document.addEventListener('pointerdown', onPointerDown, true);
+
+	return {
+		destroy() {
+			document.removeEventListener('pointerup', onPointerUp, true);
+			document.removeEventListener('pointerdown', onPointerDown, true);
+		}
+	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,38 @@
-export function clickOutside(node: HTMLElement, handler: () => void): { destroy: () => void } {
-	let pointerDownStartedInside = false;
+export function clickOutside(
+  node: HTMLElement,
+  handler: () => void
+): { destroy: () => void } {
+  let pointerDownStartedInside = false;
 
-	const onPointerDown = (event: PointerEvent) => {
-		if (node && node.contains(event.target as HTMLElement) && !event.defaultPrevented) {
-			// Set our flag to True if the pointer started from within the node.
-			// This is needed to prevent regular `pointerup` event from triggering the handler
-			pointerDownStartedInside = true;
-		}
-	};
+  const onPointerDown = (event: PointerEvent) => {
+    if (
+      !event.defaultPrevented &&
+      node?.contains(event.target as HTMLElement)
+    ) {
+      pointerDownStartedInside = true;
+    }
+  };
 
-	const onPointerUp = (event: PointerEvent) => {
-		if (node && !node.contains(event.target as HTMLElement) && !event.defaultPrevented) {
-			if (pointerDownStartedInside) {
-			} else {
-				handler();
-			}
-		}
+  const onPointerUp = (event: PointerEvent) => {
+    if (
+      !event.defaultPrevented &&
+      !pointerDownStartedInside &&
+      node &&
+      !node.contains(event.target as HTMLElement)
+    ) {
+      handler();
+    }
 
-		// Reset the flag
-		pointerDownStartedInside = false;
-	};
+    pointerDownStartedInside = false;
+  };
 
-	document.addEventListener('pointerup', onPointerUp, true);
-	document.addEventListener('pointerdown', onPointerDown, true);
+  document.addEventListener('pointerup', onPointerUp, true);
+  document.addEventListener('pointerdown', onPointerDown, true);
 
-	return {
-		destroy() {
-			document.removeEventListener('pointerup', onPointerUp, true);
-			document.removeEventListener('pointerdown', onPointerDown, true);
-		}
-	};
+  return {
+    destroy() {
+      document.removeEventListener('pointerup', onPointerUp, true);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+    },
+  };
 }


### PR DESCRIPTION
Prevent this function from being triggered if you mouse-down within the element, and then mouse-up outside of it. Imo, this should not count as a "click".